### PR TITLE
Prepare for concurrent tests

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/terraform-module-test-helper.iml" filepath="$PROJECT_DIR$/.idea/terraform-module-test-helper.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/terraform-module-test-helper.iml
+++ b/.idea/terraform-module-test-helper.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/e2etest.go
+++ b/e2etest.go
@@ -3,7 +3,6 @@ package terraform_module_test_helper
 import (
 	"fmt"
 	"github.com/stretchr/testify/require"
-	"path/filepath"
 	"log"
 	"math/rand"
 	"os"

--- a/e2etest.go
+++ b/e2etest.go
@@ -1,27 +1,19 @@
 package terraform_module_test_helper
 
 import (
-	"bytes"
-	"fmt"
-	"github.com/stretchr/testify/require"
-	"io"
-	"log"
-	"math/rand"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
-	"time"
-
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
-	terratest "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
+	"path/filepath"
+	"testing"
+	"time"
 )
 
 type TerraformOutput = map[string]interface{}
 
+/*
 var ch1 = make(chan string)
 var ch2 = make(chan string)
 
@@ -103,15 +95,17 @@ func (l *StreamTestLogger) OpenFile() error {
 	l.stream = io.ReadWriteCloser(tempFile)
 	return nil
 }
+*/
 
 // TODO: io buffer?
-func (l *StreamTestLogger) OpenMemory() error {
-	buf := bytes.Buffer{}
-	buff := make([]byte, 1024)
-	l.stream = io.ReadWriteCloser(buf)
-	return nil
-}
+//func (l *StreamTestLogger) OpenMemory() error {
+//	buf := bytes.Buffer{}
+//	buff := make([]byte, 1024)
+//	l.stream = io.ReadWriteCloser(buf)
+//	return nil
+//}
 
+/*
 func (l *StreamTestLogger) Close() error {
 	//closer, ok := l.stream.(io.Closer)
 	//if ok == true {
@@ -147,6 +141,7 @@ func PrepareFile(exampleRelativePath string) string {
 	defer tempFile.Close()
 	return tempFilePath
 }
+*/
 
 func RunE2ETest(t *testing.T, moduleRootPath, exampleRelativePath string, option terraform.Options, assertion func(*testing.T, TerraformOutput)) {
 	t.Parallel()
@@ -159,17 +154,17 @@ func RunE2ETest(t *testing.T, moduleRootPath, exampleRelativePath string, option
 
 	// create or open a temp log file
 	//tempFilePath := PrepareFile(exampleRelativePath)
-	exampleName := strings.Split(exampleRelativePath, "/")[1]
+	//exampleName := strings.Split(exampleRelativePath, "/")[1]
 
 	//option.Logger = logger.Terratest
-	option.Logger = logger.New(&StreamTestLogger{
-		exampleName: exampleName,
-	})
+	//option.Logger = logger.New(&StreamTestLogger{
+	//	exampleName: exampleName,
+	//})
 	// defer file.close()
 
 	// option.NoColor = true
 
-	defer destroy1(t, tempFilePath, option)
+	//defer destroy1(t, tempFilePath, option)
 
 	terraform.InitAndApply(t, &option)
 	if err := initAndPlanAndIdempotentAtEasyMode(t, option); err != nil {
@@ -183,7 +178,7 @@ func RunE2ETest(t *testing.T, moduleRootPath, exampleRelativePath string, option
 }
 
 func destroy1(t *testing.T, tempFilePath string, option terraform.Options) {
-	defer printLog(tempFilePath)
+	//defer printLog(tempFilePath)
 
 	option.MaxRetries = 10
 	option.TimeBetweenRetries = time.Minute
@@ -194,14 +189,14 @@ func destroy1(t *testing.T, tempFilePath string, option terraform.Options) {
 	require.NoError(t, err)
 }
 
-func printLog(tempFileDir string) {
-	// 把原来创建的临时文件关掉
-	// 把临时文件的地址发给 goroutine record()
-	ch1 <- tempFileDir
-	_ = <-ch2
-
-	// t.Failed()
-}
+//func printLog(tempFileDir string) {
+//	// 把原来创建的临时文件关掉
+//	// 把临时文件的地址发给 goroutine record()
+//	ch1 <- tempFileDir
+//	_ = <-ch2
+//
+//	// t.Failed()
+//}
 
 func destroy(t *testing.T, option terraform.Options) {
 	path := option.TerraformDir

--- a/e2etest.go
+++ b/e2etest.go
@@ -2,7 +2,12 @@ package terraform_module_test_helper
 
 import (
 	"fmt"
+	"fmt"
 	"github.com/stretchr/testify/require"
+	"log"
+	"math/rand"
+	"os"
+	"strings"
 	"log"
 	"math/rand"
 	"os"
@@ -14,6 +19,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+	terratest "github.com/gruntwork-io/terratest/modules/testing"
 	terratest "github.com/gruntwork-io/terratest/modules/testing"
 )
 
@@ -103,7 +109,92 @@ func PrepareFile(exampleRelativePath string) string {
 	return tempFileDir
 }
 
+var ch1 = make(chan string)
+var ch2 = make(chan string)
+
+func init() {
+	println("=> init")
+	go record()
+}
+
+func record() {
+	for {
+		// 收到一个地址，打开临时文件，读取，关掉文件
+		tempFileDir := <-ch1
+		fmt.Printf("======== FileDir: [%s] ========\n", tempFileDir)
+
+		//contents, err := os.ReadFile(tempFileDir)
+		//if err != nil {
+		//	log.Panicf("Failed reading file: %s", err)
+		//}
+		//fmt.Printf("\n%s", string(contents))
+
+		ch2 <- "ok"
+	}
+}
+
+var _ logger.TestLogger = &FileTestLogger{}
+
+type FileTestLogger struct {
+	// tempFilePath string
+	stream STREAM
+	ch chan
+}
+
+func (f *FileTestLogger) Logf(t terratest.TestingT, format string, args ...interface{}) {
+	tempFile, err := os.OpenFile(f.tempFilePath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	logger.DoLog(t, 3, tempFile, fmt.Sprintf(format, args...))
+}
+
+func NewFileTestLogger() *FileTestLogger {
+
+}
+
+func (f *FileTestLogger) OpenFile() error {
+	// file stream
+	exampleName := strings.Split(exampleRelativePath, "/")[1]
+	tempFileDir := fmt.Sprintf("%s/test%s%d", os.TempDir(), exampleName, rand.Intn(100))
+	tempFile, err := os.OpenFile(tempFileDir, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	f.stream = xxx
+}
+
+func (f *FileTestLogger) OpenMemory() error {
+	// io buffer?
+	f.stream = xxx
+}
+
+func (f *FileTestLogger) Close() {
+	f.stream.close()
+}
+
+func (f *FileTestLogger) Listen() {
+	// global make chan, go 监听 chan，打印到 stdout
+	// init() 里面创建一个
+	f.chan = xxx
+	io.copy to os.Stdout
+	release
+}
+
+
+func PrepareFile(exampleRelativePath string) string {
+	exampleName := strings.Split(exampleRelativePath, "/")[1]
+	tempFileDir := fmt.Sprintf("%s/test%s%d", os.TempDir(), exampleName, rand.Intn(100))
+	tempFile, err := os.OpenFile(tempFileDir, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer tempFile.Close()
+	return tempFileDir
+}
+
 func RunE2ETest(t *testing.T, moduleRootPath, exampleRelativePath string, option terraform.Options, assertion func(*testing.T, TerraformOutput)) {
+	t.Parallel()
 	t.Parallel()
 	option = retryableOptions(t, option)
 	tmpDir := test_structure.CopyTerraformFolderToTemp(t, moduleRootPath, exampleRelativePath)
@@ -129,6 +220,27 @@ func RunE2ETest(t *testing.T, moduleRootPath, exampleRelativePath string, option
 	if assertion != nil {
 		assertion(t, terraform.OutputAll(t, removeLogger(option)))
 	}
+
+	// t.Failed()
+}
+
+func destroy1(t *testing.T, tempFileDir string, option terraform.Options) {
+	defer printLog(tempFileDir)
+
+	option.MaxRetries = 10
+	option.TimeBetweenRetries = time.Minute
+	option.RetryableTerraformErrors = map[string]string{
+		".*": "Retry destroy on any error",
+	}
+	_, err := terraform.RunTerraformCommandE(t, &option, terraform.FormatArgs(&option, "destroy", "-auto-approve", "-input=false", "-refresh=false")...)
+	require.NoError(t, err)
+}
+
+func printLog(tempFileDir string) {
+	// 把原来创建的临时文件关掉
+	// 把临时文件的地址发给 goroutine record()
+	ch1 <- tempFileDir
+	_ = <-ch2
 
 	// t.Failed()
 }

--- a/e2etest.go
+++ b/e2etest.go
@@ -1,7 +1,12 @@
 package terraform_module_test_helper
 
 import (
+	"fmt"
 	"path/filepath"
+	"log"
+	"math/rand"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,18 +14,114 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
-	"github.com/stretchr/testify/require"
+	terratest "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 type TerraformOutput = map[string]interface{}
 
+var ch1 = make(chan string)
+var ch2 = make(chan string)
+
+func init() {
+	println("=> init")
+	go record()
+}
+
+func record() {
+	for {
+		// 收到一个地址，打开临时文件，读取，关掉文件
+		tempFileDir := <-ch1
+		fmt.Printf("======== FileDir: [%s] ========\n", tempFileDir)
+
+		//contents, err := os.ReadFile(tempFileDir)
+		//if err != nil {
+		//	log.Panicf("Failed reading file: %s", err)
+		//}
+		//fmt.Printf("\n%s", string(contents))
+
+		ch2 <- "ok"
+	}
+}
+
+var _ logger.TestLogger = &FileTestLogger{}
+
+type FileTestLogger struct {
+	// tempFilePath string
+	stream STREAM
+	ch chan
+}
+
+func (f *FileTestLogger) Logf(t terratest.TestingT, format string, args ...interface{}) {
+	tempFile, err := os.OpenFile(f.tempFilePath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	logger.DoLog(t, 3, tempFile, fmt.Sprintf(format, args...))
+}
+
+func NewFileTestLogger() *FileTestLogger {
+
+}
+
+func (f *FileTestLogger) OpenFile() error {
+	// file stream
+	exampleName := strings.Split(exampleRelativePath, "/")[1]
+	tempFileDir := fmt.Sprintf("%s/test%s%d", os.TempDir(), exampleName, rand.Intn(100))
+	tempFile, err := os.OpenFile(tempFileDir, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	f.stream = xxx
+}
+
+func (f *FileTestLogger) OpenMemory() error {
+	// io buffer?
+	f.stream = xxx
+}
+
+func (f *FileTestLogger) Close() {
+	f.stream.close()
+}
+
+func (f *FileTestLogger) Listen() {
+	// global make chan, go 监听 chan，打印到 stdout
+	// init() 里面创建一个
+	f.chan = xxx
+	io.copy to os.Stdout
+	release
+}
+
+
+func PrepareFile(exampleRelativePath string) string {
+	exampleName := strings.Split(exampleRelativePath, "/")[1]
+	tempFileDir := fmt.Sprintf("%s/test%s%d", os.TempDir(), exampleName, rand.Intn(100))
+	tempFile, err := os.OpenFile(tempFileDir, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer tempFile.Close()
+	return tempFileDir
+}
+
 func RunE2ETest(t *testing.T, moduleRootPath, exampleRelativePath string, option terraform.Options, assertion func(*testing.T, TerraformOutput)) {
+	t.Parallel()
+	option = retryableOptions(t, option)
 	tmpDir := test_structure.CopyTerraformFolderToTemp(t, moduleRootPath, exampleRelativePath)
 	if err := rewriteHcl(tmpDir, ""); err != nil {
 		t.Fatalf(err.Error())
 	}
 	option.TerraformDir = tmpDir
-	defer destroy(t, option)
+
+	// create or open a temp log file
+	tempFileDir := PrepareFile(exampleRelativePath)
+
+	//option.Logger = logger.Terratest
+	option.Logger = logger.New(FileTestLogger{tempFileDir})
+	// defer file.close()
+
+	// option.NoColor = true
+
+	defer destroy1(t, tempFileDir, option)
 	terraform.InitAndApply(t, &option)
 	if err := initAndPlanAndIdempotentAtEasyMode(t, option); err != nil {
 		t.Fatalf(err.Error())
@@ -28,6 +129,27 @@ func RunE2ETest(t *testing.T, moduleRootPath, exampleRelativePath string, option
 	if assertion != nil {
 		assertion(t, terraform.OutputAll(t, removeLogger(option)))
 	}
+
+	// t.Failed()
+}
+
+func destroy1(t *testing.T, tempFileDir string, option terraform.Options) {
+	defer printLog(tempFileDir)
+
+	option.MaxRetries = 10
+	option.TimeBetweenRetries = time.Minute
+	option.RetryableTerraformErrors = map[string]string{
+		".*": "Retry destroy on any error",
+	}
+	_, err := terraform.RunTerraformCommandE(t, &option, terraform.FormatArgs(&option, "destroy", "-auto-approve", "-input=false", "-refresh=false")...)
+	require.NoError(t, err)
+}
+
+func printLog(tempFileDir string) {
+	// 把原来创建的临时文件关掉
+	// 把临时文件的地址发给 goroutine record()
+	ch1 <- tempFileDir
+	_ = <-ch2
 }
 
 func destroy(t *testing.T, option terraform.Options) {

--- a/e2etest.go
+++ b/e2etest.go
@@ -1,16 +1,14 @@
 package terraform_module_test_helper
 
 import (
-	"fmt"
+	"bytes"
 	"fmt"
 	"github.com/stretchr/testify/require"
+	"io"
 	"log"
 	"math/rand"
 	"os"
-	"strings"
-	"log"
-	"math/rand"
-	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -19,7 +17,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
-	terratest "github.com/gruntwork-io/terratest/modules/testing"
 	terratest "github.com/gruntwork-io/terratest/modules/testing"
 )
 
@@ -49,15 +46,15 @@ func record() {
 	}
 }
 
-var _ logger.TestLogger = &FileTestLogger{}
+var _ logger.TestLogger = &StreamTestLogger{}
 
-type FileTestLogger struct {
-	// tempFilePath string
-	stream STREAM
-	ch chan
+type StreamTestLogger struct {
+	exampleName string
+	stream      io.ReadWriter
+	ch          chan string
 }
 
-func (f *FileTestLogger) Logf(t terratest.TestingT, format string, args ...interface{}) {
+func (f *StreamTestLogger) Logf(t terratest.TestingT, format string, args ...interface{}) {
 	tempFile, err := os.OpenFile(f.tempFilePath, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		log.Fatal(err)
@@ -65,122 +62,41 @@ func (f *FileTestLogger) Logf(t terratest.TestingT, format string, args ...inter
 	logger.DoLog(t, 3, tempFile, fmt.Sprintf(format, args...))
 }
 
-func NewFileTestLogger() *FileTestLogger {
-
+func NewStreamTestLogger(exName string, rw io.ReadWriter) *StreamTestLogger {
+	return &StreamTestLogger{
+		exampleName: exName,
+		stream:      rw,
+	}
 }
 
-func (f *FileTestLogger) OpenFile() error {
+func (f *StreamTestLogger) OpenFile() error {
 	// file stream
-	exampleName := strings.Split(exampleRelativePath, "/")[1]
-	tempFileDir := fmt.Sprintf("%s/test%s%d", os.TempDir(), exampleName, rand.Intn(100))
-	tempFile, err := os.OpenFile(tempFileDir, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
+	tempFilePath := fmt.Sprintf("%s/test%s%d", os.TempDir(), f.exampleName, rand.Intn(100))
+	tempFile, err := os.OpenFile(tempFilePath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		log.Fatal(err)
 	}
-	f.stream = xxx
+	f.stream = make([]byte)
 }
 
-func (f *FileTestLogger) OpenMemory() error {
+func (f *StreamTestLogger) OpenMemory() error {
 	// io buffer?
-	f.stream = xxx
+	f.stream = new(bytes.Buffer)
 }
 
-func (f *FileTestLogger) Close() {
-	f.stream.close()
-}
-
-func (f *FileTestLogger) Listen() {
-	// global make chan, go 监听 chan，打印到 stdout
-	// init() 里面创建一个
-	f.chan = xxx
-	io.copy to os.Stdout
-	release
-}
-
-
-func PrepareFile(exampleRelativePath string) string {
-	exampleName := strings.Split(exampleRelativePath, "/")[1]
-	tempFileDir := fmt.Sprintf("%s/test%s%d", os.TempDir(), exampleName, rand.Intn(100))
-	tempFile, err := os.OpenFile(tempFileDir, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer tempFile.Close()
-	return tempFileDir
-}
-
-var ch1 = make(chan string)
-var ch2 = make(chan string)
-
-func init() {
-	println("=> init")
-	go record()
-}
-
-func record() {
-	for {
-		// 收到一个地址，打开临时文件，读取，关掉文件
-		tempFileDir := <-ch1
-		fmt.Printf("======== FileDir: [%s] ========\n", tempFileDir)
-
-		//contents, err := os.ReadFile(tempFileDir)
-		//if err != nil {
-		//	log.Panicf("Failed reading file: %s", err)
-		//}
-		//fmt.Printf("\n%s", string(contents))
-
-		ch2 <- "ok"
+func (f *StreamTestLogger) Close() {
+	closer, ok := f.stream.(io.Closer)
+	if ok == true {
+		f.stream.Close()
 	}
 }
 
-var _ logger.TestLogger = &FileTestLogger{}
-
-type FileTestLogger struct {
-	// tempFilePath string
-	stream STREAM
-	ch chan
+func (f *StreamTestLogger) Listen() {
+	// init() 里面 global make chan, 新建 goroutine 监听 chan，打印到 stdout，release
+	f.ch = make(chan string)
+	io.Copy(os.Stdout, f.stream.(io.Reader))
+	// release
 }
-
-func (f *FileTestLogger) Logf(t terratest.TestingT, format string, args ...interface{}) {
-	tempFile, err := os.OpenFile(f.tempFilePath, os.O_CREATE|os.O_RDWR, 0644)
-	if err != nil {
-		log.Fatal(err)
-	}
-	logger.DoLog(t, 3, tempFile, fmt.Sprintf(format, args...))
-}
-
-func NewFileTestLogger() *FileTestLogger {
-
-}
-
-func (f *FileTestLogger) OpenFile() error {
-	// file stream
-	exampleName := strings.Split(exampleRelativePath, "/")[1]
-	tempFileDir := fmt.Sprintf("%s/test%s%d", os.TempDir(), exampleName, rand.Intn(100))
-	tempFile, err := os.OpenFile(tempFileDir, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
-	if err != nil {
-		log.Fatal(err)
-	}
-	f.stream = xxx
-}
-
-func (f *FileTestLogger) OpenMemory() error {
-	// io buffer?
-	f.stream = xxx
-}
-
-func (f *FileTestLogger) Close() {
-	f.stream.close()
-}
-
-func (f *FileTestLogger) Listen() {
-	// global make chan, go 监听 chan，打印到 stdout
-	// init() 里面创建一个
-	f.chan = xxx
-	io.copy to os.Stdout
-	release
-}
-
 
 func PrepareFile(exampleRelativePath string) string {
 	exampleName := strings.Split(exampleRelativePath, "/")[1]
@@ -195,7 +111,6 @@ func PrepareFile(exampleRelativePath string) string {
 
 func RunE2ETest(t *testing.T, moduleRootPath, exampleRelativePath string, option terraform.Options, assertion func(*testing.T, TerraformOutput)) {
 	t.Parallel()
-	t.Parallel()
 	option = retryableOptions(t, option)
 	tmpDir := test_structure.CopyTerraformFolderToTemp(t, moduleRootPath, exampleRelativePath)
 	if err := rewriteHcl(tmpDir, ""); err != nil {
@@ -204,15 +119,19 @@ func RunE2ETest(t *testing.T, moduleRootPath, exampleRelativePath string, option
 	option.TerraformDir = tmpDir
 
 	// create or open a temp log file
-	tempFileDir := PrepareFile(exampleRelativePath)
+	//tempFilePath := PrepareFile(exampleRelativePath)
+	exampleName := strings.Split(exampleRelativePath, "/")[1]
 
 	//option.Logger = logger.Terratest
-	option.Logger = logger.New(FileTestLogger{tempFileDir})
+	option.Logger = logger.New(&StreamTestLogger{
+		exampleName: exampleName,
+	})
 	// defer file.close()
 
 	// option.NoColor = true
 
-	defer destroy1(t, tempFileDir, option)
+	defer destroy1(t, tempFilePath, option)
+
 	terraform.InitAndApply(t, &option)
 	if err := initAndPlanAndIdempotentAtEasyMode(t, option); err != nil {
 		t.Fatalf(err.Error())
@@ -224,8 +143,8 @@ func RunE2ETest(t *testing.T, moduleRootPath, exampleRelativePath string, option
 	// t.Failed()
 }
 
-func destroy1(t *testing.T, tempFileDir string, option terraform.Options) {
-	defer printLog(tempFileDir)
+func destroy1(t *testing.T, tempFilePath string, option terraform.Options) {
+	defer printLog(tempFilePath)
 
 	option.MaxRetries = 10
 	option.TimeBetweenRetries = time.Minute
@@ -243,25 +162,6 @@ func printLog(tempFileDir string) {
 	_ = <-ch2
 
 	// t.Failed()
-}
-
-func destroy1(t *testing.T, tempFileDir string, option terraform.Options) {
-	defer printLog(tempFileDir)
-
-	option.MaxRetries = 10
-	option.TimeBetweenRetries = time.Minute
-	option.RetryableTerraformErrors = map[string]string{
-		".*": "Retry destroy on any error",
-	}
-	_, err := terraform.RunTerraformCommandE(t, &option, terraform.FormatArgs(&option, "destroy", "-auto-approve", "-input=false", "-refresh=false")...)
-	require.NoError(t, err)
-}
-
-func printLog(tempFileDir string) {
-	// 把原来创建的临时文件关掉
-	// 把临时文件的地址发给 goroutine record()
-	ch1 <- tempFileDir
-	_ = <-ch2
 }
 
 func destroy(t *testing.T, option terraform.Options) {

--- a/e2etest.go
+++ b/e2etest.go
@@ -2,6 +2,7 @@ package terraform_module_test_helper
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"path/filepath"
 	"log"
 	"math/rand"

--- a/e2etest.go
+++ b/e2etest.go
@@ -6,6 +6,8 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/require"
+	"log"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -13,138 +15,16 @@ import (
 
 type TerraformOutput = map[string]interface{}
 
-/*
-var ch1 = make(chan string)
-var ch2 = make(chan string)
-
 func init() {
 	println("=> init")
-	l := NewStreamTestLogger()
-	// init() 里面 global make chan, 新建 goroutine 监听 chan，打印到 stdout，release
-	go record(l)
+	go record()
 }
 
-func record(l *StreamTestLogger) {
-	l.Listen()
+func record() {
 
-	for {
-		// 收到一个地址，打开临时文件，读取，关掉文件
-		tempFileDir := <-ch1
-		fmt.Printf("======== FileDir: [%s] ========\n", tempFileDir)
-
-		//contents, err := os.ReadFile(tempFileDir)
-		//if err != nil {
-		//	log.Panicf("Failed reading file: %s", err)
-		//}
-		//fmt.Printf("\n%s", string(contents))
-
-		ch2 <- "ok"
-	}
 }
-
-var _ logger.TestLogger = &StreamTestLogger{}
-
-type StreamTestLogger struct {
-	exampleName string
-	stream      io.ReadWriteCloser
-	ch          chan byte
-}
-
-func (l *StreamTestLogger) Logf(t terratest.TestingT, format string, args ...interface{}) {
-	logger.DoLog(t, 3, l.stream.(io.Writer), fmt.Sprintf(format, args...))
-}
-
-func NewStreamTestLogger() *StreamTestLogger {
-	return &StreamTestLogger{}
-}
-
-func (l *StreamTestLogger) Chan() <-chan byte {
-	return l.ch
-}
-
-func (l *StreamTestLogger) ReadFrom(num int) ([]byte, error) {
-	p := make([]byte, num)
-	n, err := l.stream.(io.Reader).Read(p)
-	if n > 0 {
-		return p[:n], nil
-	}
-	return p, err
-}
-
-func (l *StreamTestLogger) WriteTo(p []byte) (int, error) {
-	return fmt.Fprintln(l.stream.(io.Writer), p)
-}
-
-func (l *StreamTestLogger) WriteToChan(p []byte) (int, error) {
-	n := 0
-	for _, b := range p {
-		l.ch <- p[b]
-		n++
-	}
-	return n, nil
-}
-
-func (l *StreamTestLogger) OpenFile() error {
-	// file stream
-	tempFilePath := fmt.Sprintf("%s/test%s%d", os.TempDir(), l.exampleName, rand.Intn(100))
-	tempFile, err := os.OpenFile(tempFilePath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
-	if err != nil {
-		log.Fatal(err)
-		return err
-	}
-	l.stream = io.ReadWriteCloser(tempFile)
-	return nil
-}
-*/
-
-// TODO: io buffer?
-//func (l *StreamTestLogger) OpenMemory() error {
-//	buf := bytes.Buffer{}
-//	buff := make([]byte, 1024)
-//	l.stream = io.ReadWriteCloser(buf)
-//	return nil
-//}
-
-/*
-func (l *StreamTestLogger) Close() error {
-	//closer, ok := l.stream.(io.Closer)
-	//if ok == true {
-	//	l.stream.Close()
-	//} else {
-	//	return ok
-	//}
-	err := l.stream.(io.Closer).Close()
-	if err != nil {
-		log.Fatal(err)
-	}
-	return err
-}
-
-func (l *StreamTestLogger) Listen() {
-	// init() 里面 global make chan, 新建 goroutine 监听 chan，打印到 stdout，release
-	l.ch = make(chan byte, 1024)
-	_, err := io.Copy(os.Stdout, l.stream.(io.Reader))
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-	// release
-}
-
-func PrepareFile(exampleRelativePath string) string {
-	exampleName := strings.Split(exampleRelativePath, "/")[1]
-	tempFilePath := fmt.Sprintf("%s/test%s%d", os.TempDir(), exampleName, rand.Intn(100))
-	tempFile, err := os.OpenFile(tempFilePath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer tempFile.Close()
-	return tempFilePath
-}
-*/
 
 func RunE2ETest(t *testing.T, moduleRootPath, exampleRelativePath string, option terraform.Options, assertion func(*testing.T, TerraformOutput)) {
-	t.Parallel()
 	option = retryableOptions(t, option)
 	tmpDir := test_structure.CopyTerraformFolderToTemp(t, moduleRootPath, exampleRelativePath)
 	if err := rewriteHcl(tmpDir, ""); err != nil {
@@ -152,19 +32,15 @@ func RunE2ETest(t *testing.T, moduleRootPath, exampleRelativePath string, option
 	}
 	option.TerraformDir = tmpDir
 
-	// create or open a temp log file
-	//tempFilePath := PrepareFile(exampleRelativePath)
-	//exampleName := strings.Split(exampleRelativePath, "/")[1]
-
-	//option.Logger = logger.Terratest
-	//option.Logger = logger.New(&StreamTestLogger{
-	//	exampleName: exampleName,
-	//})
-	// defer file.close()
-
-	// option.NoColor = true
-
-	//defer destroy1(t, tempFilePath, option)
+	option.NoColor = true
+	f, err := os.OpenFile("logs.txt", os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+	option.Logger = logger.New(NewStreamLogger(f))
+	//option.Logger = logger.New(NewStreamLogger(buff))
+	defer destroy(t, option)
 
 	terraform.InitAndApply(t, &option)
 	if err := initAndPlanAndIdempotentAtEasyMode(t, option); err != nil {
@@ -173,30 +49,7 @@ func RunE2ETest(t *testing.T, moduleRootPath, exampleRelativePath string, option
 	if assertion != nil {
 		assertion(t, terraform.OutputAll(t, removeLogger(option)))
 	}
-
-	// t.Failed()
 }
-
-func destroy1(t *testing.T, tempFilePath string, option terraform.Options) {
-	//defer printLog(tempFilePath)
-
-	option.MaxRetries = 10
-	option.TimeBetweenRetries = time.Minute
-	option.RetryableTerraformErrors = map[string]string{
-		".*": "Retry destroy on any error",
-	}
-	_, err := terraform.RunTerraformCommandE(t, &option, terraform.FormatArgs(&option, "destroy", "-auto-approve", "-input=false", "-refresh=false")...)
-	require.NoError(t, err)
-}
-
-//func printLog(tempFileDir string) {
-//	// 把原来创建的临时文件关掉
-//	// 把临时文件的地址发给 goroutine record()
-//	ch1 <- tempFileDir
-//	_ = <-ch2
-//
-//	// t.Failed()
-//}
 
 func destroy(t *testing.T, option terraform.Options) {
 	path := option.TerraformDir

--- a/e2etest_test.go
+++ b/e2etest_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestE2EExample(t *testing.T) {
+func TestE2EExampleTest(t *testing.T) {
 	RunE2ETest(t, "./", "example/basic", terraform.Options{
 		Upgrade: true,
 	}, func(t *testing.T, output TerraformOutput) {

--- a/e2etest_test.go
+++ b/e2etest_test.go
@@ -7,24 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestE2EExampleTest(t *testing.T) {
-	RunE2ETest(t, "./", "example/basic", terraform.Options{
-		Upgrade: true,
-	}, func(t *testing.T, output TerraformOutput) {
-		resId, ok := output["resource_id"].(string)
-		assert.True(t, ok)
-		assert.NotEqual(t, "", resId, "expected output `resource_id`")
-	})
-
-	RunE2ETest(t, "./", "example/basic2", terraform.Options{
-		Upgrade: true,
-	}, func(t *testing.T, output TerraformOutput) {
-		resId, ok := output["resource_id2"].(string)
-		assert.True(t, ok)
-		assert.NotEqual(t, "", resId, "expected output `resource_id`")
-	})
-}
-
 func TestE2EExample(t *testing.T) {
 	RunE2ETest(t, "./", "example/basic", terraform.Options{
 		Upgrade: true,
@@ -32,5 +14,27 @@ func TestE2EExample(t *testing.T) {
 		resId, ok := output["resource_id"].(string)
 		assert.True(t, ok)
 		assert.NotEqual(t, "", resId, "expected output `resource_id`")
+	})
+}
+
+func TestE2EParallel(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		RunE2ETest(t, "./", "example/basic", terraform.Options{
+			Upgrade: true,
+		}, func(t *testing.T, output TerraformOutput) {
+			resId, ok := output["resource_id"].(string)
+			assert.True(t, ok)
+			assert.NotEqual(t, "", resId, "expected output `resource_id`")
+		})
+	})
+
+	t.Run("basic2", func(t *testing.T) {
+		RunE2ETest(t, "./", "example/basic2", terraform.Options{
+			Upgrade: true,
+		}, func(t *testing.T, output TerraformOutput) {
+			resId, ok := output["resource_id2"].(string)
+			assert.True(t, ok)
+			assert.NotEqual(t, "", resId, "expected output `resource_id`")
+		})
 	})
 }

--- a/e2etest_test.go
+++ b/e2etest_test.go
@@ -26,10 +26,10 @@ func TestE2EExampleTest(t *testing.T) {
 }
 
 func TestE2EExample(t *testing.T) {
-	RunE2ETest(t, "./", "example/basic2", terraform.Options{
+	RunE2ETest(t, "./", "example/basic", terraform.Options{
 		Upgrade: true,
 	}, func(t *testing.T, output TerraformOutput) {
-		resId, ok := output["resource_id2"].(string)
+		resId, ok := output["resource_id"].(string)
 		assert.True(t, ok)
 		assert.NotEqual(t, "", resId, "expected output `resource_id`")
 	})

--- a/e2etest_test.go
+++ b/e2etest_test.go
@@ -15,4 +15,22 @@ func TestE2EExampleTest(t *testing.T) {
 		assert.True(t, ok)
 		assert.NotEqual(t, "", resId, "expected output `resource_id`")
 	})
+
+	RunE2ETest(t, "./", "example/basic2", terraform.Options{
+		Upgrade: true,
+	}, func(t *testing.T, output TerraformOutput) {
+		resId, ok := output["resource_id2"].(string)
+		assert.True(t, ok)
+		assert.NotEqual(t, "", resId, "expected output `resource_id`")
+	})
+}
+
+func TestE2EExample(t *testing.T) {
+	RunE2ETest(t, "./", "example/basic2", terraform.Options{
+		Upgrade: true,
+	}, func(t *testing.T, output TerraformOutput) {
+		resId, ok := output["resource_id2"].(string)
+		assert.True(t, ok)
+		assert.NotEqual(t, "", resId, "expected output `resource_id`")
+	})
 }

--- a/example/basic2/main.tf
+++ b/example/basic2/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "test" {}
+
+output "resource_id2" {
+  value = null_resource.test.id
+}

--- a/stream_logger.go
+++ b/stream_logger.go
@@ -1,0 +1,49 @@
+package terraform_module_test_helper
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/testing"
+	"io"
+	"os"
+	"sync"
+)
+
+var _ logger.TestLogger = new(StreamLogger)
+
+// SerializedLogger Global Logger for Std output
+var SerializedLogger = NewStreamLogger(os.Stdout)
+
+type StreamLogger struct {
+	stream io.ReadWriter
+	mu     *sync.Mutex
+}
+
+func NewStreamLogger(stream io.ReadWriter) *StreamLogger {
+	return &StreamLogger{
+		stream: stream,
+		mu:     new(sync.Mutex),
+	}
+}
+
+func (s *StreamLogger) Logf(t testing.TestingT, format string, args ...interface{}) {
+	logger.DoLog(t, 3, s.stream, fmt.Sprintf(format, args...))
+}
+
+// PipeTo s.stream -> destLogger.stream
+func (s *StreamLogger) PipeTo(destLogger *StreamLogger) error {
+	_, err := io.Copy(destLogger.stream, s.stream)
+	return err
+}
+
+// PipeFrom s.stream <- src.stream
+func (s *StreamLogger) PipeFrom(srcLogger *StreamLogger) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, err := io.Copy(s.stream, srcLogger.stream)
+	return err
+}
+
+func (s *StreamLogger) Close() error {
+	return SerializedLogger.PipeFrom(s)
+}

--- a/stream_logger.go
+++ b/stream_logger.go
@@ -1,6 +1,7 @@
 package terraform_module_test_helper
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/testing"
@@ -11,12 +12,16 @@ import (
 
 var _ logger.TestLogger = new(StreamLogger)
 
-// SerializedLogger Global Logger for Std output
-var SerializedLogger = NewStreamLogger(os.Stdout)
+var serializedLogger = NewStreamLogger(os.Stdout)
 
 type StreamLogger struct {
 	stream io.ReadWriter
 	mu     *sync.Mutex
+}
+
+func NewMemoryLogger() *StreamLogger {
+	buff := new(bytes.Buffer)
+	return NewStreamLogger(buff)
 }
 
 func NewStreamLogger(stream io.ReadWriter) *StreamLogger {
@@ -30,13 +35,6 @@ func (s *StreamLogger) Logf(t testing.TestingT, format string, args ...interface
 	logger.DoLog(t, 3, s.stream, fmt.Sprintf(format, args...))
 }
 
-// PipeTo s.stream -> destLogger.stream
-func (s *StreamLogger) PipeTo(destLogger *StreamLogger) error {
-	_, err := io.Copy(destLogger.stream, s.stream)
-	return err
-}
-
-// PipeFrom s.stream <- src.stream
 func (s *StreamLogger) PipeFrom(srcLogger *StreamLogger) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -45,5 +43,9 @@ func (s *StreamLogger) PipeFrom(srcLogger *StreamLogger) error {
 }
 
 func (s *StreamLogger) Close() error {
-	return SerializedLogger.PipeFrom(s)
+	c, ok := s.stream.(io.Closer)
+	if ok {
+		defer func() { _ = c.Close() }()
+	}
+	return serializedLogger.PipeFrom(s)
 }

--- a/stream_logger_test.go
+++ b/stream_logger_test.go
@@ -14,7 +14,7 @@ import (
  */
 func TestStreamLoggerShouldLogSth(t *testing.T) {
 	buff := new(bytes.Buffer)
-	var l *StreamLogger = NewStreamLogger(buff)
+	l := NewStreamLogger(buff)
 	log := "hello"
 	l.Logf(t, log)
 	assert.Contains(t, buff.String(), log)

--- a/stream_logger_test.go
+++ b/stream_logger_test.go
@@ -63,16 +63,15 @@ func TestStreamLoggerClose(t *testing.T) {
 	assert.Contains(t, destBuff.String(), log)
 }
 
-func TestStreamLoggerPipeIsSerialize(t *testing.T) {
-	log1 := "hello "
-	srcBuff1 := bytes.NewBufferString(log1)
-	srcLogger1 := NewStreamLogger(srcBuff1)
-
+func TestStreamLoggerPipeIsSerialized(t *testing.T) {
 	destBuff := new(bytes.Buffer)
 	dummyLogger := NewStreamLogger(destBuff)
 	stub := gostub.Stub(&SerializedLogger, dummyLogger)
 	defer stub.Reset()
 
+	log1 := "hello "
+	srcBuff1 := bytes.NewBufferString(log1)
+	srcLogger1 := NewStreamLogger(srcBuff1)
 	err := srcLogger1.Close()
 	require.Nil(t, err)
 	time.Sleep(500 * time.Millisecond)
@@ -82,6 +81,13 @@ func TestStreamLoggerPipeIsSerialize(t *testing.T) {
 	srcLogger2 := NewStreamLogger(srcBuff2)
 	err = srcLogger2.Close()
 	require.Nil(t, err)
+	time.Sleep(500 * time.Millisecond)
 
-	assert.Contains(t, destBuff.String(), log1+log2)
+	log3 := "!!!"
+	srcBuff3 := bytes.NewBufferString(log3)
+	srcLogger3 := NewStreamLogger(srcBuff3)
+	err = srcLogger3.Close()
+	require.Nil(t, err)
+
+	assert.Contains(t, destBuff.String(), log1+log2+log3)
 }

--- a/stream_logger_test.go
+++ b/stream_logger_test.go
@@ -6,12 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	"time"
 )
 
-/*
- * 需求：传入一个 buffer，StreamLogger 应该把需要 log 的内容打到 buffer 里面
- */
 func TestStreamLoggerShouldLogSth(t *testing.T) {
 	buff := new(bytes.Buffer)
 	l := NewStreamLogger(buff)
@@ -20,17 +16,6 @@ func TestStreamLoggerShouldLogSth(t *testing.T) {
 	assert.Contains(t, buff.String(), log)
 }
 
-/**
-1. Logger can pipe stream to another logger
-2. Logger can be closed, when closed, pipe stream to another logger
-3. Develop a global logger.
-	- 别的 Logger 可以把 buffer 内的东西传给 GL,
-	- GL 可以把这些 buffer 的内容打印到（PipeTo）STDOUT
-*/
-
-/*
- * 写一个 PipeTo(destination), 使得 srcLogger 把 srcBuff -> destLogger 的 destBuff
- */
 func TestStreamLoggerCanPipeLogsToAnotherStreamLogger(t *testing.T) {
 	log := "hello"
 	srcBuff := bytes.NewBufferString(log)
@@ -42,52 +27,17 @@ func TestStreamLoggerCanPipeLogsToAnotherStreamLogger(t *testing.T) {
 	assert.Contains(t, destBuff.String(), log)
 }
 
-/*
- * 写一个 Close(), 使得每次 Logger.Close() 的时候，GL 都会自动读 logger.stream 里的值
- */
 func TestStreamLoggerClose(t *testing.T) {
 	log := "hello"
 	srcBuff := bytes.NewBufferString(log)
 	srcLogger := NewStreamLogger(srcBuff)
 
-	// 由于 SerializedLogger 的输出在 STDOUT，很难做测试
-	// 打桩，在 line56 临时把 SerializedLogger 的值换成 dummyLogger
-	// line59 defer stub.Reset() 把 SerializedLogger 再换回来
 	destBuff := new(bytes.Buffer)
 	dummyLogger := NewStreamLogger(destBuff)
-	stub := gostub.Stub(&SerializedLogger, dummyLogger)
+	stub := gostub.Stub(&serializedLogger, dummyLogger)
 	defer stub.Reset()
 
 	err := srcLogger.Close()
 	require.Nil(t, err)
 	assert.Contains(t, destBuff.String(), log)
-}
-
-func TestStreamLoggerPipeIsSerialized(t *testing.T) {
-	destBuff := new(bytes.Buffer)
-	dummyLogger := NewStreamLogger(destBuff)
-	stub := gostub.Stub(&SerializedLogger, dummyLogger)
-	defer stub.Reset()
-
-	log1 := "hello "
-	srcBuff1 := bytes.NewBufferString(log1)
-	srcLogger1 := NewStreamLogger(srcBuff1)
-	err := srcLogger1.Close()
-	require.Nil(t, err)
-	time.Sleep(500 * time.Millisecond)
-
-	log2 := "world"
-	srcBuff2 := bytes.NewBufferString(log2)
-	srcLogger2 := NewStreamLogger(srcBuff2)
-	err = srcLogger2.Close()
-	require.Nil(t, err)
-	time.Sleep(500 * time.Millisecond)
-
-	log3 := "!!!"
-	srcBuff3 := bytes.NewBufferString(log3)
-	srcLogger3 := NewStreamLogger(srcBuff3)
-	err = srcLogger3.Close()
-	require.Nil(t, err)
-
-	assert.Contains(t, destBuff.String(), log1+log2+log3)
 }

--- a/stream_logger_test.go
+++ b/stream_logger_test.go
@@ -1,0 +1,87 @@
+package terraform_module_test_helper
+
+import (
+	"bytes"
+	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+/*
+ * 需求：传入一个 buffer，StreamLogger 应该把需要 log 的内容打到 buffer 里面
+ */
+func TestStreamLoggerShouldLogSth(t *testing.T) {
+	buff := new(bytes.Buffer)
+	var l *StreamLogger = NewStreamLogger(buff)
+	log := "hello"
+	l.Logf(t, log)
+	assert.Contains(t, buff.String(), log)
+}
+
+/**
+1. Logger can pipe stream to another logger
+2. Logger can be closed, when closed, pipe stream to another logger
+3. Develop a global logger.
+	- 别的 Logger 可以把 buffer 内的东西传给 GL,
+	- GL 可以把这些 buffer 的内容打印到（PipeTo）STDOUT
+*/
+
+/*
+ * 写一个 PipeTo(destination), 使得 srcLogger 把 srcBuff -> destLogger 的 destBuff
+ */
+func TestStreamLoggerCanPipeLogsToAnotherStreamLogger(t *testing.T) {
+	log := "hello"
+	srcBuff := bytes.NewBufferString(log)
+	srcLogger := NewStreamLogger(srcBuff)
+	destBuff := new(bytes.Buffer)
+	destLogger := NewStreamLogger(destBuff)
+	err := destLogger.PipeFrom(srcLogger)
+	require.Nil(t, err)
+	assert.Contains(t, destBuff.String(), log)
+}
+
+/*
+ * 写一个 Close(), 使得每次 Logger.Close() 的时候，GL 都会自动读 logger.stream 里的值
+ */
+func TestStreamLoggerClose(t *testing.T) {
+	log := "hello"
+	srcBuff := bytes.NewBufferString(log)
+	srcLogger := NewStreamLogger(srcBuff)
+
+	// 由于 SerializedLogger 的输出在 STDOUT，很难做测试
+	// 打桩，在 line56 临时把 SerializedLogger 的值换成 dummyLogger
+	// line59 defer stub.Reset() 把 SerializedLogger 再换回来
+	destBuff := new(bytes.Buffer)
+	dummyLogger := NewStreamLogger(destBuff)
+	stub := gostub.Stub(&SerializedLogger, dummyLogger)
+	defer stub.Reset()
+
+	err := srcLogger.Close()
+	require.Nil(t, err)
+	assert.Contains(t, destBuff.String(), log)
+}
+
+func TestStreamLoggerPipeIsSerialize(t *testing.T) {
+	log1 := "hello "
+	srcBuff1 := bytes.NewBufferString(log1)
+	srcLogger1 := NewStreamLogger(srcBuff1)
+
+	destBuff := new(bytes.Buffer)
+	dummyLogger := NewStreamLogger(destBuff)
+	stub := gostub.Stub(&SerializedLogger, dummyLogger)
+	defer stub.Reset()
+
+	err := srcLogger1.Close()
+	require.Nil(t, err)
+	time.Sleep(500 * time.Millisecond)
+
+	log2 := "world"
+	srcBuff2 := bytes.NewBufferString(log2)
+	srcLogger2 := NewStreamLogger(srcBuff2)
+	err = srcLogger2.Close()
+	require.Nil(t, err)
+
+	assert.Contains(t, destBuff.String(), log1+log2)
+}


### PR DESCRIPTION
- Defined a StreamLogger implements logger.TestLogger, to insure serialized output during concurrent tests. 
- Wrote corresponding unit tests.