### PR TITLE
Enhance error test record

### DIFF
--- a/e2etest.go
+++ b/e2etest.go
@@ -30,7 +30,7 @@ var initLock = &sync.Mutex{}
 type TerraformOutput = map[string]interface{}
 
 type testExecutor interface {
-	TearDown(t *T, rootDir string, modulePath string)
+	TearDown(t testingT, rootDir string, modulePath string)
 	Logger() logger.TestLogger
 }
 
@@ -38,7 +38,7 @@ var _ testExecutor = e2eTestExecutor{}
 
 type e2eTestExecutor struct{}
 
-func (e2eTestExecutor) TearDown(t *T, rootDir string, modulePath string) {
+func (e2eTestExecutor) TearDown(t testingT, rootDir string, modulePath string) {
 	s := SuccessTestVersionSnapshot(rootDir, modulePath)
 	if t.Failed() {
 		s = FailedTestVersionSnapshot(rootDir, modulePath, t.ErrorMessage())
@@ -55,15 +55,15 @@ func RunE2ETest(t *testing.T, moduleRootPath, exampleRelativePath string, option
 	runE2ETest(newT(t), moduleRootPath, exampleRelativePath, option, assertion)
 }
 
-func runE2ETest(t *T, moduleRootPath, exampleRelativePath string, option terraform.Options, assertion func(*testing.T, TerraformOutput)) {
-	t.initAndApplyAndIdempotentTest(moduleRootPath, exampleRelativePath, option, false, false, assertion, e2eTestExecutor{})
+func runE2ETest(t testingT, moduleRootPath, exampleRelativePath string, option terraform.Options, assertion func(*testing.T, TerraformOutput)) {
+	initAndApplyAndIdempotentTest(t, moduleRootPath, exampleRelativePath, option, false, false, assertion, e2eTestExecutor{})
 }
 
 func RunE2ETestWithOption(t *testing.T, moduleRootPath, exampleRelativePath string, testOption TestOptions) {
-	newT(t).initAndApplyAndIdempotentTest(moduleRootPath, exampleRelativePath, testOption.TerraformOptions, false, testOption.SkipIdempotentCheck, testOption.Assertion, e2eTestExecutor{})
+	initAndApplyAndIdempotentTest(newT(t), moduleRootPath, exampleRelativePath, testOption.TerraformOptions, false, testOption.SkipIdempotentCheck, testOption.Assertion, e2eTestExecutor{})
 }
 
-func (t *T) initAndApplyAndIdempotentTest(moduleRootPath string, exampleRelativePath string, option terraform.Options, skipDestroy bool, skipCheckIdempotent bool, assertion func(*testing.T, TerraformOutput), executor testExecutor) {
+func initAndApplyAndIdempotentTest(t testingT, moduleRootPath string, exampleRelativePath string, option terraform.Options, skipDestroy bool, skipCheckIdempotent bool, assertion func(*testing.T, TerraformOutput), executor testExecutor) {
 	tryParallel(t)
 	defer executor.TearDown(t, moduleRootPath, exampleRelativePath)
 	testDir := filepath.Join(moduleRootPath, exampleRelativePath)
@@ -99,7 +99,7 @@ func (t *T) initAndApplyAndIdempotentTest(moduleRootPath string, exampleRelative
 	}
 }
 
-func copyTerraformFolderToTemp(t *T, moduleRootPath string, exampleRelativePath string) string {
+func copyTerraformFolderToTemp(t testingT, moduleRootPath string, exampleRelativePath string) string {
 	unlock := copyLock.Lock(exampleRelativePath)
 	defer unlock()
 	tmpDir := test_structure.CopyTerraformFolderToTemp(t, moduleRootPath, exampleRelativePath)
@@ -117,7 +117,7 @@ func tfInit(t terratest.TestingT, options *terraform.Options) {
 	terraform.Init(t, options)
 }
 
-func destroy(t *T, option terraform.Options) {
+func destroy(t testingT, option terraform.Options) {
 	path := option.TerraformDir
 	if !files.IsExistingDir(path) || !files.FileExists(filepath.Join(path, "terraform.tfstate")) {
 		return

--- a/e2etest_test.go
+++ b/e2etest_test.go
@@ -24,9 +24,7 @@ func TestE2EExampleTest(t *testing.T) {
 }
 
 func TestE2EExample_testFail(t *testing.T) {
-	t.Skip("do not run this test unless you'd like to verify `Error` section in `example/should_fail` folder")
-	sut := newT(t)
-	expectFailure(sut, func(t *T) {
+	sut := expectFailure(t, func(t testingT) {
 		runE2ETest(t, "./", "example/should_fail", terraform.Options{
 			Upgrade: true,
 			NoColor: true,
@@ -34,13 +32,12 @@ func TestE2EExample_testFail(t *testing.T) {
 	})
 	msg := sut.ErrorMessage()
 	require.Contains(t, msg, "Resource postcondition failed")
-	t.SkipNow()
 }
 
 func TestE2EExample_WithoutIdempotent(t *testing.T) {
 	currentId := routine.Goid()
 	originStub := initAndPlanAndIdempotentAtEasyMode
-	stub := gostub.Stub(&initAndPlanAndIdempotentAtEasyMode, func(t *T, opts terraform.Options) error {
+	stub := gostub.Stub(&initAndPlanAndIdempotentAtEasyMode, func(t testingT, opts terraform.Options) error {
 		// Do not impact other tests.
 		id := routine.Goid()
 		if id != currentId {

--- a/e2etest_test.go
+++ b/e2etest_test.go
@@ -1,6 +1,7 @@
 package terraform_module_test_helper
 
 import (
+	"github.com/stretchr/testify/require"
 	"os"
 	"runtime"
 	"strconv"
@@ -22,10 +23,24 @@ func TestE2EExampleTest(t *testing.T) {
 	})
 }
 
+func TestE2EExample_testFail(t *testing.T) {
+	t.Skip("do not run this test unless you'd like to verify `Error` section in `example/should_fail` folder")
+	sut := newT(t)
+	expectFailure(sut, func(t *T) {
+		runE2ETest(t, "./", "example/should_fail", terraform.Options{
+			Upgrade: true,
+			NoColor: true,
+		}, nil)
+	})
+	msg := sut.ErrorMessage()
+	require.Contains(t, msg, "Resource postcondition failed")
+	t.SkipNow()
+}
+
 func TestE2EExample_WithoutIdempotent(t *testing.T) {
 	currentId := routine.Goid()
 	originStub := initAndPlanAndIdempotentAtEasyMode
-	stub := gostub.Stub(&initAndPlanAndIdempotentAtEasyMode, func(t *testing.T, opts terraform.Options) error {
+	stub := gostub.Stub(&initAndPlanAndIdempotentAtEasyMode, func(t *T, opts terraform.Options) error {
 		// Do not impact other tests.
 		id := routine.Goid()
 		if id != currentId {
@@ -61,4 +76,8 @@ func TestE2EExampleTest_setEnvWontCausePanicOnParallel(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestE2EExampleTest_failedTestShouldGenerateErrorMessage(t *testing.T) {
+
 }

--- a/example/should_fail/main.tf
+++ b/example/should_fail/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.3"
+    }
+  }
+}
+resource "random_string" "test" {
+  length = 10
+  lifecycle {
+    postcondition {
+      condition       = length(self.result) != 10
+      error_message   = "must fail"
+    }
+  }
+}

--- a/test_runner.go
+++ b/test_runner.go
@@ -1,0 +1,114 @@
+package terraform_module_test_helper
+
+import (
+	"fmt"
+	terratest "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/require"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type testingT interface {
+	terratest.TestingT
+	T() *testing.T
+}
+
+var _ testingT = &T{}
+
+type T struct {
+	failed        bool
+	mockMode      bool
+	t             *testing.T
+	errorMessages []string
+}
+
+func (t *T) T() *testing.T {
+	return t.t
+}
+
+func newT(t *testing.T) *T {
+	return &T{t: t}
+}
+
+func (t *T) error(message string) {
+	t.errorMessages = append(t.errorMessages, message)
+}
+
+func (t *T) Failed() bool {
+	return t.failed
+}
+
+func (t *T) Fail() {
+	t.failed = true
+	t.error("Fail")
+	t.t.Fail()
+}
+
+func (t *T) FailNow() {
+	t.failed = true
+	t.error("FailNow")
+	if t.mockMode {
+		runtime.Goexit()
+		return
+	}
+	t.t.FailNow()
+}
+
+func (t *T) Fatal(args ...interface{}) {
+	t.failed = true
+	t.error("Fatal:" + fmt.Sprintln(args...))
+	t.t.Fatal(args...)
+}
+
+func (t *T) Fatalf(format string, args ...interface{}) {
+	t.failed = true
+	t.error("Fatal:" + fmt.Sprintf(format, args...))
+	t.t.Fatalf(format, args...)
+}
+
+func (t *T) Error(args ...interface{}) {
+	t.error("Error:" + fmt.Sprintln(args...))
+	t.t.Error(args...)
+}
+
+func (t *T) Errorf(format string, args ...interface{}) {
+	t.error("Error:" + fmt.Sprintf(format, args...))
+	t.t.Errorf(format, args...)
+}
+
+func (t *T) Name() string {
+	return t.t.Name()
+}
+
+func (t *T) ErrorMessage() string {
+	sb := strings.Builder{}
+	for i := 0; i < len(t.errorMessages); i++ {
+		sb.WriteString(t.errorMessages[i])
+		if i < len(t.errorMessages)-1 {
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
+}
+
+func expectFailure(t *T, f func(tt *T)) {
+	stub := gostub.Stub(&t.mockMode, true)
+	defer stub.Reset()
+	var wg sync.WaitGroup
+	// setup the barrier
+	wg.Add(1)
+	// start a co-routine to execute the test function f
+	// and release the barrier at its end
+	go func() {
+		defer wg.Done()
+		f(t)
+	}()
+
+	// wait for the barrier.
+	wg.Wait()
+	// verify fail now is invoked
+	require.True(t, t.failed)
+}

--- a/unittest.go
+++ b/unittest.go
@@ -11,12 +11,12 @@ var _ testExecutor = unitTestExecutor{}
 
 type unitTestExecutor struct{}
 
-func (u unitTestExecutor) TearDown(t *testing.T, rootDir string, modulePath string) {}
+func (u unitTestExecutor) TearDown(t *T, rootDir string, modulePath string) {}
 
 func (u unitTestExecutor) Logger() logger.TestLogger {
 	return logger.Discard
 }
 
 func RunUnitTest(t *testing.T, moduleRootPath, exampleRelativePath string, option terraform.Options, assertion func(*testing.T, TerraformOutput)) {
-	initAndApplyAndIdempotentTest(t, moduleRootPath, exampleRelativePath, option, true, true, assertion, unitTestExecutor{})
+	newT(t).initAndApplyAndIdempotentTest(moduleRootPath, exampleRelativePath, option, true, true, assertion, unitTestExecutor{})
 }

--- a/unittest.go
+++ b/unittest.go
@@ -11,12 +11,12 @@ var _ testExecutor = unitTestExecutor{}
 
 type unitTestExecutor struct{}
 
-func (u unitTestExecutor) TearDown(t *T, rootDir string, modulePath string) {}
+func (u unitTestExecutor) TearDown(t testingT, rootDir string, modulePath string) {}
 
 func (u unitTestExecutor) Logger() logger.TestLogger {
 	return logger.Discard
 }
 
 func RunUnitTest(t *testing.T, moduleRootPath, exampleRelativePath string, option terraform.Options, assertion func(*testing.T, TerraformOutput)) {
-	newT(t).initAndApplyAndIdempotentTest(moduleRootPath, exampleRelativePath, option, true, true, assertion, unitTestExecutor{})
+	initAndApplyAndIdempotentTest(newT(t), moduleRootPath, exampleRelativePath, option, true, true, assertion, unitTestExecutor{})
 }

--- a/upgradetest.go
+++ b/upgradetest.go
@@ -51,7 +51,7 @@ func ModuleUpgradeTest(t *testing.T, owner, repo, moduleFolderRelativeToRoot, cu
 	require.NoError(wrappedT, err)
 }
 
-func tryParallel(t *T) {
+func tryParallel(t testingT) {
 	defer func() {
 		if recover() != nil {
 			t.T().Log("cannot run test in parallel, skip parallel")
@@ -143,7 +143,7 @@ func diffTwoVersions(t *T, opts terraform.Options, originTerraformDir string, ne
 	return initAndPlanAndIdempotentAtEasyMode(t, opts)
 }
 
-var initAndPlanAndIdempotentAtEasyMode = func(t *T, opts terraform.Options) error {
+var initAndPlanAndIdempotentAtEasyMode = func(t testingT, opts terraform.Options) error {
 	opts.PlanFilePath = filepath.Join(opts.TerraformDir, "tf.plan")
 	opts.Logger = logger.Discard
 	exitCode := initAndPlanWithExitCode(t, &opts)

--- a/upgradetest_test.go
+++ b/upgradetest_test.go
@@ -21,7 +21,7 @@ func TestModuleUpgradeTest(t *testing.T) {
 	stub.Stub(&cloneGithubRepo, func(owner string, repo string, tag *string) (string, error) {
 		return "./", nil
 	})
-	err := moduleUpgrade(t, "lonegunmanb", "terraform-module-test-helper", "example/upgrade/example/version_upgrade", "../../../after_upgrade", terraform.Options{Upgrade: true}, 1)
+	err := moduleUpgrade(newT(t), "lonegunmanb", "terraform-module-test-helper", "example/upgrade/example/version_upgrade", "../../../after_upgrade", terraform.Options{Upgrade: true}, 1)
 	if err == nil {
 		assert.FailNow(t, "expect test failure, but test success")
 	}
@@ -38,7 +38,7 @@ func TestModuleUpgradeTestShouldSkipV0(t *testing.T) {
 	stub.Stub(&cloneGithubRepo, func(owner string, repo string, tag *string) (string, error) {
 		return "./", nil
 	})
-	err := moduleUpgrade(t, "lonegunmanb", "terraform-module-test-helper", "example/upgrade", "./", terraform.Options{Upgrade: true}, 0)
+	err := moduleUpgrade(newT(t), "lonegunmanb", "terraform-module-test-helper", "example/upgrade", "./", terraform.Options{Upgrade: true}, 0)
 	assert.Equal(t, SkipV0Error, err)
 }
 
@@ -134,7 +134,7 @@ func TestNoValidVersion(t *testing.T) {
 
 func TestAddNewOutputShouldNotFailTheTest(t *testing.T) {
 	tmpDir := test_structure.CopyTerraformFolderToTemp(t, "./example/output_upgrade", "test")
-	err := diffTwoVersions(t, terraform.Options{
+	err := diffTwoVersions(newT(t), terraform.Options{
 		Upgrade: true,
 	}, tmpDir, "../after")
 	assert.Nil(t, err)
@@ -142,7 +142,7 @@ func TestAddNewOutputShouldNotFailTheTest(t *testing.T) {
 
 func TestNoChange(t *testing.T) {
 	tmpDir := test_structure.CopyTerraformFolderToTemp(t, "./example/output_upgrade", "test")
-	err := diffTwoVersions(t, terraform.Options{
+	err := diffTwoVersions(newT(t), terraform.Options{
 		Upgrade: true,
 	}, tmpDir, "../before")
 	assert.Nil(t, err)

--- a/version_helper_test.go
+++ b/version_helper_test.go
@@ -39,6 +39,7 @@ func TestVersionSnapshotToString(t *testing.T) {
 	require.Equal(t, snapshot.Time.Format(time.RFC822), strings.TrimPrefix(title, "## "))
 	require.Contains(t, s, "Success: true")
 	require.Contains(t, s, snapshot.Versions)
+	require.Contains(t, s, NoErrorMessage)
 }
 
 func TestOutputNewTestVersionSnapshot(t *testing.T) {


### PR DESCRIPTION
Now the `Error` section in TestRecord.md is always empty, this pr try to collect the test failure message and export them to TestRecord.md, if there's no error and test passed successfully, then export `No error was found.`.