### PR TITLE
add upgrade tests to check for destructive changes

### DIFF
--- a/example/after_destructive_upgrade/main.tf
+++ b/example/after_destructive_upgrade/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0"
+    }
+  }
+}
+
+resource "null_resource" "test" {
+  triggers = {
+    version = "2"
+  }
+}
+
+output "result" {
+  value = null_resource.test.id
+}

--- a/example/upgrade_destructive/example/version_upgrade/main.tf
+++ b/example/upgrade_destructive/example/version_upgrade/main.tf
@@ -1,0 +1,7 @@
+module "destructive_change_test" {
+  source = "../../"
+}
+
+output "result" {
+  value = module.destructive_change_test.result
+}

--- a/example/upgrade_destructive/main.tf
+++ b/example/upgrade_destructive/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0"
+    }
+  }
+}
+
+resource "null_resource" "test" {
+  triggers = {
+    version = "1"
+  }
+}
+
+output "result" {
+  value = null_resource.test.id
+}

--- a/upgradedestructivetest.go
+++ b/upgradedestructivetest.go
@@ -1,0 +1,131 @@
+package terraform_module_test_helper
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/files"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+	//terratest "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/hashicorp/terraform-json"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/semver"
+)
+
+type moduleUpgradeOptions struct {
+	allowV0Testing bool
+}
+
+//goland:noinspection GoUnusedExportedFunction
+func ModuleUpgradeDestructiveTest(t *testing.T, owner, repo, moduleFolderRelativeToRoot, currentModulePath string, opts terraform.Options, currentMajorVer int) {
+	wrappedT := newT(t)
+	tryParallel(wrappedT)
+	logger.Log(wrappedT, fmt.Sprintf("===> Starting test for destructive changes in %s/%s/examples/%s, ", owner, repo, moduleFolderRelativeToRoot))
+
+	streamEnv := os.Getenv("DEBUG_ENABLE_LOG_STREAMING")
+	stream, _ := strconv.ParseBool(streamEnv) // Defaults to false if parsing fails or var is not set
+
+	if stream {
+		opts.Logger = logger.Default
+	} else {
+		memLogger := NewMemoryLogger()
+		opts.Logger = logger.New(memLogger)
+		defer func() {
+			if err := memLogger.Close(); err != nil {
+				t.Logf("Error closing memory logger: %v", err)
+			}
+		}()
+	}
+
+	opts = setupRetryLogic(opts)
+
+	upgradeOpts := &moduleUpgradeOptions{
+		allowV0Testing: true,
+	}
+
+	err := moduleCheckIfDestructive(wrappedT, owner, repo, moduleFolderRelativeToRoot, currentModulePath, retryableOptions(t, opts), currentMajorVer, upgradeOpts)
+	if err == CannotTestError {
+		t.Skip(err.Error())
+	}
+	require.NoError(wrappedT, err)
+}
+
+func moduleCheckIfDestructive(t *T, owner string, repo string, moduleFolderRelativeToRoot string, newModulePath string, opts terraform.Options, currentMajorVer int, upgradeOpts *moduleUpgradeOptions) error {
+	if !upgradeOpts.allowV0Testing && currentMajorVer == 0 {
+		return SkipV0Error
+	}
+	latestTag, err := getLatestTag(owner, repo, currentMajorVer)
+	if err != nil {
+		return err
+	}
+	if !upgradeOpts.allowV0Testing && semver.Major(latestTag) == "v0" {
+		return SkipV0Error
+	}
+	tmpDirForTag, err := cloneGithubRepo(owner, repo, &latestTag)
+	if err != nil {
+		return err
+	}
+
+	fullTerraformModuleFolder := filepath.Join(tmpDirForTag, moduleFolderRelativeToRoot)
+
+	exists := files.FileExists(fullTerraformModuleFolder)
+	if !exists {
+		return CannotTestError
+	}
+	tmpTestDir := test_structure.CopyTerraformFolderToTemp(t, tmpDirForTag, moduleFolderRelativeToRoot)
+	defer func() {
+		_ = os.RemoveAll(filepath.Clean(tmpTestDir))
+	}()
+	return diffForDestructiveChanges(t, opts, tmpTestDir, newModulePath)
+}
+
+func diffForDestructiveChanges(t *T, opts terraform.Options, originTerraformDir string, newModulePath string) error {
+	opts.TerraformDir = originTerraformDir
+	defer destroy(t, opts)
+	initAndApply(t, &opts)
+	overrideModuleSourceToCurrentPath(t, originTerraformDir, newModulePath)
+	return initAndPlanAndNotDestructiveChanges(t, opts)
+}
+
+var initAndPlanAndNotDestructiveChanges = func(t testingT, opts terraform.Options) error {
+	opts.PlanFilePath = filepath.Join(opts.TerraformDir, "tf.plan")
+	opts.Logger = logger.Discard
+	exitCode := initAndPlanWithExitCode(t, &opts)
+	plan := terraform.InitAndPlanAndShowWithStruct(t, &opts)
+	changes := plan.ResourceChangesMap
+
+	// opts.Logger = logger.Default
+	// jsonBytes, _ := json.MarshalIndent(changes, "", "  ")
+	// logger.Log(t, string(jsonBytes))
+
+	if exitCode == 0 || ignoreOnlyAddOrUpdate(changes) {
+		return nil
+	}
+	return fmt.Errorf("terraform configuration contains destructive operations (breaking changes):%s", terraform.Plan(t, &opts))
+}
+
+func ignoreOnlyAddOrUpdate(changes map[string]*tfjson.ResourceChange) bool {
+	// Return false (fail) if we see any "delete" or "replace."
+	for _, rc := range changes {
+			if rc == nil || rc.Change == nil {
+					continue
+			}
+			actions := rc.Change.Actions
+			if actions == nil {
+					continue
+			}
+			// If Terraform lists multiple actions (e.g., ["delete", "create"] for a replace),
+			// then if any action is "delete" or "replace," we fail.
+			for _, a := range actions {
+					if a == "delete" || a == "replace" {
+							return false
+					}
+			}
+	}
+	return true
+}

--- a/upgradedestructivetest_test.go
+++ b/upgradedestructivetest_test.go
@@ -1,0 +1,99 @@
+package terraform_module_test_helper
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+func TestIgnoreOnlyAddOrUpdate_AllowsCreateAndUpdate(t *testing.T) {
+	changes := map[string]*tfjson.ResourceChange{
+		"a": {Change: &tfjson.Change{Actions: tfjson.Actions{"create"}}},
+		"b": {Change: &tfjson.Change{Actions: tfjson.Actions{"update"}}},
+		"c": {Change: &tfjson.Change{Actions: tfjson.Actions{"no-op"}}},
+	}
+	require.True(t, ignoreOnlyAddOrUpdate(changes))
+}
+
+func TestIgnoreOnlyAddOrUpdate_FailsOnDeleteOrReplace(t *testing.T) {
+	changes1 := map[string]*tfjson.ResourceChange{
+		"a": {Change: &tfjson.Change{Actions: tfjson.Actions{"delete"}}},
+	}
+	require.False(t, ignoreOnlyAddOrUpdate(changes1))
+
+	changes2 := map[string]*tfjson.ResourceChange{
+		"a": {Change: &tfjson.Change{Actions: tfjson.Actions{"delete", "create"}}},
+		"b": {Change: &tfjson.Change{Actions: tfjson.Actions{"replace"}}},
+	}
+	require.False(t, ignoreOnlyAddOrUpdate(changes2))
+}
+
+func TestModuleCheckIfDestructive_FailOnReplace(t *testing.T) {
+	// Stub out GitHub tag lookup and clone so we stay in this repo
+	stub := gostub.Stub(&getLatestTag, func(owner, repo string, currentMajorVer int) (string, error) {
+			// Simulate finding a previous tag for the major version
+			return "v1.0.0", nil
+	})
+	defer stub.Reset()
+	stub.Stub(&cloneGithubRepo, func(owner, repo string, tag *string) (string, error) {
+			// Simulate cloning the repo root for the old tag
+			return ".", nil
+	})
+
+	wt := newT(t)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	err = moduleCheckIfDestructive(
+			wt,
+			"Azure", // Mock owner
+			"terraform-module-test-helper", // Mock repo
+			// Path to the example harness using the 'before' module structure (relative to repo root)
+			"example/upgrade_destructive/example/version_upgrade",
+			// Absolute path to the 'after' module code
+			filepath.Join(cwd, "example", "after_destructive_upgrade"),
+			terraform.Options{Upgrade: true},
+			1, // Mock current major version (must be > 0 to avoid SkipV0Error)
+			&moduleUpgradeOptions{allowV0Testing: true}, // Options for the destructive check
+	)
+
+	require.Error(t, err, "Expected an error due to destructive changes, but got nil")
+	assert.Contains(t, err.Error(), "destructive operations", "Error message should indicate destructive operations")
+}
+
+
+func TestModuleCheckIfDestructive_PassOnCreateOnly(t *testing.T) {
+	// Stub out GitHub tag lookup and clone
+	stub := gostub.Stub(&getLatestTag, func(owner, repo string, currentMajorVer int) (string, error) {
+			return "v1.0.0", nil
+	})
+	defer stub.Reset()
+	stub.Stub(&cloneGithubRepo, func(owner, repo string, tag *string) (string, error) {
+			return ".", nil
+	})
+
+	wt := newT(t)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	err = moduleCheckIfDestructive(
+			wt,
+			"Azure", // Mock owner
+			"terraform-module-test-helper", // Mock repo
+			// Path to the example harness using the 'before' module structure (relative to repo root)
+			"example/upgrade/example/version_upgrade",
+			// Absolute path to the 'after' module code
+			filepath.Join(cwd, "example", "after_upgrade"),
+			terraform.Options{Upgrade: true},
+			1, // Mock current major version
+			&moduleUpgradeOptions{allowV0Testing: true}, // Options for the destructive check
+	)
+
+	require.NoError(t, err, "Expected no error for non-destructive changes, but got: %v", err)
+}


### PR DESCRIPTION
as discussed with @matt-FFFFFF I wrote this to help test for destructive changes during module upgrades.

related part: https://github.com/Azure/avmtester/pull/10

the initial target use case is the final pieces of the conversion of the vnet module to azapi.  in general I see it being useful for other module updates, especially when doing azurerm to azapi.

the idea is to look for any changes that are replaces or deletes, ignoring those that are add/update-in-place

it is also designed to run against v0 modules, I've added a flag to permit that

I'm also unclear why logs have to be buffered, because I thought each test woudl be fanned out by the github action, not within the go module?

I haven't wired it into tfmodScaffold or the AVM template yet, but happy to continue if of value.

I'm very happy for critique on any aspects - this is the first time I've tried to write go (though, Copilot was very helpful!)